### PR TITLE
Fixed dead links on the vis.gl website

### DIFF
--- a/src/data/repos.yaml
+++ b/src/data/repos.yaml
@@ -4,7 +4,7 @@
   ID: MDEwOlJlcG9zaXRvcnk0ODAzMDIwNA==
   img: deck.png
   url: uber/deck.gl
-  page: http://uber.github.io/deck.gl/#/
+  page: https://deck.gl/
   description: A high-performance WebGL 2 rendering framework for big data visualizations that integrates perfectly with reactive applications.
   badges:
     - badge: react first
@@ -14,7 +14,7 @@
   img: luma.png
   name: luma.gl
   owner: uber
-  page: http://uber.github.io/luma.gl/#/
+  page: https://luma.gl/
   url: uber/luma.gl
   type: FRAMEWORK
   description: A comprehensive set of WebGL 2 components targeting high-performance rendering and GPGPU computing.
@@ -25,7 +25,7 @@
   img: react-map-gl.png
   name: react-map-gl
   owner: uber
-  page: https://uber.github.io/react-map-gl/#/
+  page: https://visgl.github.io/react-map-gl/
   url: uber/react-map-gl
   description: A comprehensive React wrapper for mapbox-gl. Designed to work seamlessly as a basemap for geospatial visualizations.
   badges:


### PR DESCRIPTION
Updated website links for:
deck.gl
luma.gl
react-map-gl